### PR TITLE
Add Apple MPS fallback to automatic device selection

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -40,11 +40,17 @@ def set_seed(seed: int) -> None:
 
 
 def select_device(device: str | None = None) -> torch.device:
-    """Return a torch.device, preferring CUDA if available."""
+    """Return a torch.device, preferring CUDA, then Apple MPS, then CPU."""
 
     if device:
         return torch.device(device)
-    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+
+    return torch.device("cpu")
 
 
 def accuracy_from_logits(logits: torch.Tensor, targets: torch.Tensor) -> float:

--- a/utils.py
+++ b/utils.py
@@ -44,10 +44,12 @@ def select_device(device: str | None = None) -> torch.device:
 
     if device:
         return torch.device(device)
+
     if torch.cuda.is_available():
         return torch.device("cuda")
 
-    if torch.backends.mps.is_available():
+    mps_backend = getattr(torch.backends, "mps", None)
+    if mps_backend is not None and mps_backend.is_available():
         return torch.device("mps")
 
     return torch.device("cpu")


### PR DESCRIPTION
### Motivation
- Ensure the code runs on macOS with Apple Silicon by falling back to MPS when CUDA is not available, so `select_device` picks a usable accelerator automatically.

### Description
- Update `select_device` in `utils.py` to return `torch.device("cuda")` if `torch.cuda.is_available()`, then `torch.device("mps")` if `torch.backends.mps.is_available()`, otherwise `torch.device("cpu")`, and refresh the function docstring while preserving explicit `--device` overrides.

### Testing
- Ran `python -m py_compile utils.py train.py infer.py datasets.py models.py` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b911848c8332b9c6f38fb634ae52)